### PR TITLE
feat: add websocket echo endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ app.get("/ws", (c: HonoContext) => {
                 return new Response("Expected WebSocket", { status: 400 });
         }
         const pair = new WebSocketPair();
-        const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+        const { 0: client, 1: server } = pair;
         server.accept();
         server.addEventListener("message", (event) => {
                 server.send(event.data);

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,25 @@ app.use("*", async (c, next) => {
 app.options("*", () => new Response(null, { headers: CORS_HEADERS }));
 
 /**
+ * GET /ws
+ * WebSocket echo endpoint for realtime communication.
+ */
+app.get("/ws", (c: HonoContext) => {
+        if (c.req.header("Upgrade")?.toLowerCase() !== "websocket") {
+                return new Response("Expected WebSocket", { status: 400 });
+        }
+        const pair = new WebSocketPair();
+        const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+        server.accept();
+        server.addEventListener("message", (event) => {
+                server.send(event.data);
+        });
+        server.addEventListener("close", () => console.log("WebSocket closed"));
+        server.addEventListener("error", (err) => console.error("WebSocket error", err));
+        return new Response(null, { status: 101, webSocket: client });
+});
+
+/**
  * GET /health
  * Lightweight liveness probe for uptime checks & CI smoke tests.
  * Returns 200 with { ok: true } if the worker is reachable.


### PR DESCRIPTION
## Summary
- add `/ws` endpoint with Cloudflare Workers WebSocket handshake
- echo messages, log close/error events

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c818153158832e8f6c8c5c1ef6947b