### PR TITLE
chore: streamline command status websocket cleanup

### DIFF
--- a/src/modules/command_status_ws.ts
+++ b/src/modules/command_status_ws.ts
@@ -57,19 +57,6 @@ function subscribeToCommand(socket: WebSocket, commandId: string) {
   socketSubscriptions.set(socket, commandId)
 }
 
-function unsubscribe(socket: WebSocket) {
-  const existing = socketSubscriptions.get(socket)
-  if (!existing) {
-    return
-  }
-  const sockets = commandSubscriptions.get(existing)
-  sockets?.delete(socket)
-  if (sockets && sockets.size === 0) {
-    commandSubscriptions.delete(existing)
-  }
-  socketSubscriptions.delete(socket)
-}
-
 function parseMessageData(data: unknown): string {
   if (typeof data === 'string') {
     return data
@@ -131,7 +118,7 @@ export function setupCommandStatusSocket(socket: WebSocket) {
     }
 
     if (action === 'unsubscribe') {
-      unsubscribe(socket)
+      cleanupSocket(socket)
       safeSend(socket, {
         type: 'unsubscribed'
       })
@@ -145,7 +132,6 @@ export function setupCommandStatusSocket(socket: WebSocket) {
   })
 
   const closeHandler = () => {
-    unsubscribe(socket)
     cleanupSocket(socket)
   }
 


### PR DESCRIPTION
## Summary
- remove the redundant unsubscribe helper in the command status websocket module
- reuse cleanupSocket for explicit unsubscribe events and connection close handlers to reduce duplication

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfbce4e6c4832eb7ebd7d0452992cb