### PR TITLE
Add GitHub Copilot MCP workspace server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A sophisticated Cloudflare Worker that provides AI-powered GitHub workflow autom
 - **Repository Discovery**: Automatically discovers and indexes repositories from GitHub App installations
 - **AI Analysis**: Comprehensive repository analysis using Workers AI
 - **Command Tracking**: Tracks and manages GitHub commands and operations
+- **GitHub Copilot MCP Workspace**: SSE-based MCP server that shares configs, instructions, questions, and task state with GitHub Copilot tools
 
 ### 📊 Research & Analytics
 - **Repository Research**: Automated research orchestration across multiple repositories

--- a/docs/GITHUB_COPILOT_MCP.md
+++ b/docs/GITHUB_COPILOT_MCP.md
@@ -1,0 +1,52 @@
+# GitHub Copilot MCP Workspace
+
+This document summarizes how the GH Bot worker exposes a Model Context Protocol (MCP) workspace that GitHub Copilot can use to synchronize configuration, instructions, questions, and task management data.
+
+## Overview
+- **Endpoint**: `GET {{worker_base_url}}/mcp/github-copilot/sse`
+- **Protocol**: Server-Sent Events (SSE) following the MCP handshake model
+- **Tools exposed**:
+  - `get_copilot_config`
+  - `list_instructions`
+  - `submit_question`
+  - `list_questions`
+  - `list_tasks`
+  - `create_manual_task`
+  - `update_task_status`
+
+The migration `0009_github_copilot_mcp.sql` seeds tables that back these tools and registers the server as a default MCP integration for repositories that do not already have custom MCP tooling configured.
+
+## Data Stores
+
+| Table | Purpose |
+| --- | --- |
+| `copilot_configs` | Key/value configuration payloads returned by the `get_copilot_config` tool. |
+| `copilot_instructions` | Instruction documents Copilot can retrieve via `list_instructions`. |
+| `copilot_questions` | Records submitted by Copilot when it invokes `submit_question`. |
+| `copilot_task_links` | Manual tasks that Copilot can create, list, or update. |
+
+The MCP server also surfaces recent `agent_generation_requests` and `infrastructure_guidance_requests` as read-only tasks so Copilot has full context when coordinating work.
+
+## Recommended Copilot Workflow
+
+1. **Connect** to the SSE endpoint. The server will emit:
+   - A session descriptor with capability metadata
+   - A list of resources Copilot can fetch (`copilot://configs`, `copilot://instructions`, `copilot://tasks`, `copilot://questions/open`)
+   - A tool schema definition payload
+2. **Load instructions** using `list_instructions` or the `copilot://instructions` resource.
+3. **Synchronize configuration** via `get_copilot_config`, optionally filtering by key.
+4. **Plan work** by calling `list_tasks`. Copilot can create new manual tasks or update existing ones using the exposed tools.
+5. **Ask clarifying questions** with `submit_question`. These records are tracked in the `copilot_questions` table so humans can triage and respond.
+6. **Update statuses** using `update_task_status` once work is complete to keep the shared task board accurate.
+
+## Security Notes
+- The MCP endpoints use the same Worker runtime authentication model as the rest of the API.
+- Data is stored in D1 and benefits from the existing operational logging via `mcp_tools_logs`.
+- No secrets are exposed through the MCP server; configuration values seeded in the migration are descriptive metadata only.
+
+## Extending the Workspace
+- Add new instruction documents by inserting records into `copilot_instructions`.
+- Register additional configuration keys in `copilot_configs` to make them queryable by Copilot.
+- Extend task automation by inserting new sources into `copilot_task_links` or joining additional system tables inside `listTasks`.
+- Update the default MCP server payload inside `migrations/0009_github_copilot_mcp.sql` (and `DEFAULT_MCP_TOOLS` in `src/modules/mcp_tools.ts`) if you deploy the Worker to a different hostname.
+

--- a/migrations/0009_github_copilot_mcp.sql
+++ b/migrations/0009_github_copilot_mcp.sql
@@ -1,0 +1,134 @@
+-- Migration 0009: GitHub Copilot MCP workspace support
+-- Adds configuration, instruction, question, and task tables used by the GitHub Copilot MCP server
+-- and seeds a default MCP server configuration so new repositories automatically receive the tool.
+
+-- Ensure supporting tables exist
+CREATE TABLE IF NOT EXISTS copilot_configs (
+    config_key TEXT PRIMARY KEY,
+    config_value TEXT NOT NULL,
+    description TEXT,
+    category TEXT,
+    updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+    created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE TABLE IF NOT EXISTS copilot_instructions (
+    instruction_id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    summary TEXT,
+    content TEXT,
+    tags TEXT,
+    source TEXT,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+    updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE TABLE IF NOT EXISTS copilot_questions (
+    question_id TEXT PRIMARY KEY,
+    repo TEXT,
+    question TEXT NOT NULL,
+    context_json TEXT,
+    status TEXT NOT NULL DEFAULT 'open',
+    response TEXT,
+    metadata TEXT,
+    created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+    updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+CREATE TABLE IF NOT EXISTS copilot_task_links (
+    task_id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    description TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    source TEXT NOT NULL DEFAULT 'manual',
+    source_reference TEXT,
+    priority INTEGER DEFAULT 3,
+    due_at INTEGER,
+    metadata TEXT,
+    created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000),
+    updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now') * 1000)
+);
+
+-- Helpful indexes for filtering
+CREATE INDEX IF NOT EXISTS idx_copilot_configs_category ON copilot_configs(category);
+CREATE INDEX IF NOT EXISTS idx_copilot_instructions_tags ON copilot_instructions(tags);
+CREATE INDEX IF NOT EXISTS idx_copilot_instructions_active ON copilot_instructions(is_active);
+CREATE INDEX IF NOT EXISTS idx_copilot_questions_status ON copilot_questions(status);
+CREATE INDEX IF NOT EXISTS idx_copilot_questions_created ON copilot_questions(created_at);
+CREATE INDEX IF NOT EXISTS idx_copilot_tasks_status ON copilot_task_links(status);
+CREATE INDEX IF NOT EXISTS idx_copilot_tasks_due ON copilot_task_links(due_at);
+
+-- Seed default configuration values
+INSERT OR IGNORE INTO copilot_configs (config_key, config_value, description, category)
+VALUES
+    (
+        'default_instruction_pack',
+        '{"version":"2025-02-11","instructions_uri":"copilot://instructions","summary":"Primary operating instructions for the GH Bot Copilot workspace."}',
+        'Primary instruction document that Copilot should load on connect.',
+        'instructions'
+    ),
+    (
+        'task_sync_preferences',
+        '{"poll_interval_minutes":5,"sync_sources":["manual","agent_generation","infra_guidance"]}',
+        'Controls how frequently Copilot should sync the task dashboard.',
+        'tasks'
+    ),
+    (
+        'question_routing',
+        '{"default_assignee":"triage","status_flow":["open","acknowledged","answered","archived"]}',
+        'Defines routing metadata for questions created by GitHub Copilot.',
+        'questions'
+    );
+
+-- Seed baseline instruction content
+INSERT OR IGNORE INTO copilot_instructions (instruction_id, title, summary, content, tags, source)
+VALUES
+    (
+        'operational-guardrails',
+        'Operational guardrails for GH Bot automations',
+        'Step-by-step checklist Copilot should follow before triggering automation or deployment actions.',
+        '1. Confirm repository ownership and recent activity.\n2. Review open incidents or critical alerts.\n3. Validate deployment prerequisites (wrangler config, secrets, migrations).\n4. Use `/status` task summary before high-impact actions.\n5. Capture outputs and link them to the related task record.',
+        '["operations","safety","deployments"]',
+        'docs/GITHUB_COPILOT_MCP.md'
+    ),
+    (
+        'collaboration-etiquette',
+        'Collaboration etiquette for pairing with maintainers',
+        'Communication guidance for Copilot-initiated PR reviews, comments, and check-ins.',
+        '• Always provide concise context referencing the file path and change summary.\n• Offer remediation steps or follow-up tasks when flagging risks.\n• Use the MCP task tools to create or link actionable items.\n• Prefer async updates via status threads when the maintainer is inactive.',
+        '["communication","pull-requests"]',
+        'docs/GITHUB_COPILOT_MCP.md'
+    ),
+    (
+        'task-handoff-template',
+        'Task hand-off template',
+        'Template Copilot should follow when transitioning work back to humans.',
+        'Summary:\n- What changed\n- Tests executed\n- Remaining risks\nNext steps:\n- Link or create GH issue\n- Update MCP task status\n- Provide recommended follow-up window',
+        '["tasks","handoff"]',
+        'docs/GITHUB_COPILOT_MCP.md'
+    );
+
+-- Add a placeholder manual task so dashboards have an example entry
+INSERT OR IGNORE INTO copilot_task_links (task_id, title, description, status, source, priority, metadata)
+VALUES (
+    'seed-task-initialize-copilot-workspace',
+    'Verify GitHub Copilot MCP workspace wiring',
+    'Confirm Copilot can connect to the new MCP endpoint, list resources, and call task APIs.',
+    'in_progress',
+    'manual',
+    2,
+    '{"checklist":["Connect via Copilot","Fetch instructions","Sync tasks"],"owner":"platform"}'
+);
+
+-- Ensure the GitHub Copilot MCP server is registered as a default tool
+INSERT OR IGNORE INTO default_mcp_tools (tool_name, tool_config, description, is_active)
+VALUES (
+    'github-copilot-mcp',
+    '{"type":"sse","url":"{{worker_base_url}}/mcp/github-copilot/sse","tools":["get_copilot_config","list_instructions","submit_question","list_questions","list_tasks","create_manual_task","update_task_status"]}',
+    'GH Bot GitHub Copilot workspace MCP server for configuration, instructions, Q&A, and task operations.',
+    1
+);
+
+INSERT OR IGNORE INTO schema_migrations (version, applied_at)
+VALUES ('0009_github_copilot_mcp', strftime('%s', 'now') * 1000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,12 @@ import { handleWebhook } from "./routes/webhook";
 import { asyncGeneratorToStream } from "./stream";
 import { parseColbyCommand } from "./modules/colby";
 import { setupCommandStatusSocket } from "./modules/command_status_ws";
+import {
+    CopilotToolInvocation,
+    createCopilotMcpSseResponse,
+    handleCopilotResourceRequest,
+    handleCopilotToolInvocation,
+} from "./modules/github_copilot_mcp";
 
 /**
  * Runtime bindings available to this Worker.
@@ -275,6 +281,49 @@ app.get("/demo/stream", (_c: HonoContext) => {
     return new Response(asyncGeneratorToStream(run()), {
         headers: { "Content-Type": "text/event-stream" },
     });
+});
+
+/**
+ * GET /mcp/github-copilot/sse
+ * Model Context Protocol SSE endpoint used by GitHub Copilot tools.
+ */
+app.get("/mcp/github-copilot/sse", async (c: HonoContext) => {
+    return await createCopilotMcpSseResponse(c.env.DB);
+});
+
+/**
+ * GET /mcp/github-copilot/resource?uri=...
+ * Retrieves MCP resource payloads (configs, instructions, tasks, questions).
+ */
+app.get("/mcp/github-copilot/resource", async (c: HonoContext) => {
+    const uri = c.req.query("uri");
+    if (!uri) {
+        return c.json({ error: "uri query parameter required" }, 400);
+    }
+    try {
+        const payload = await handleCopilotResourceRequest(c.env.DB, uri);
+        return c.json(payload);
+    } catch (error) {
+        console.error("[MCP] Failed to fetch resource", { uri, error });
+        const message = error instanceof Error ? error.message : "Unknown error";
+        return c.json({ error: message }, 500);
+    }
+});
+
+/**
+ * POST /mcp/github-copilot/tool
+ * Invokes MCP tool handlers for GitHub Copilot.
+ */
+app.post("/mcp/github-copilot/tool", async (c: HonoContext) => {
+    try {
+        const body = (await c.req.json()) as CopilotToolInvocation;
+        const result = await handleCopilotToolInvocation(c.env.DB, body);
+        return c.json(result);
+    } catch (error) {
+        console.error("[MCP] Tool invocation failed", error);
+        const message = error instanceof Error ? error.message : "Unknown error";
+        return c.json({ ok: false, error: message }, 400);
+    }
 });
 
 /**

--- a/src/modules/github_copilot_mcp.ts
+++ b/src/modules/github_copilot_mcp.ts
@@ -1,0 +1,646 @@
+import { DEFAULT_MCP_TOOLS } from "./mcp_tools";
+
+const encoder = new TextEncoder();
+
+export type CopilotToolInvocation = {
+  tool: string;
+  arguments?: Record<string, unknown> | null;
+};
+
+interface CopilotConfigRow {
+  config_key: string;
+  config_value: string;
+  description: string | null;
+  category: string | null;
+  updated_at: number;
+}
+
+interface CopilotInstructionRow {
+  instruction_id: string;
+  title: string;
+  summary: string | null;
+  content: string | null;
+  tags: string | null;
+  source: string | null;
+  updated_at: number;
+  is_active: number;
+}
+
+interface CopilotQuestionRow {
+  question_id: string;
+  repo: string | null;
+  question: string;
+  context_json: string | null;
+  status: string;
+  response: string | null;
+  metadata: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface CopilotTaskRow {
+  task_id: string;
+  title: string;
+  description: string | null;
+  status: string;
+  source: string;
+  source_reference: string | null;
+  priority: number | null;
+  due_at: number | null;
+  metadata: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+type DbResult<T> = {
+  results?: T[];
+};
+
+function safeJsonParse<T>(value: string | null | undefined): T | null {
+  if (!value) return null;
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    console.warn("[COPILOT_MCP] Failed to parse JSON", { value, error });
+    return null;
+  }
+}
+
+function encodeSse(data: unknown): Uint8Array {
+  return encoder.encode(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+async function fetchCopilotConfigs(db: D1Database, keys?: string[]): Promise<Array<Record<string, unknown>>> {
+  let query = `
+    SELECT config_key, config_value, description, category, updated_at
+    FROM copilot_configs
+  `;
+
+  const bindings: unknown[] = [];
+
+  if (keys?.length) {
+    const placeholders = keys.map(() => "?").join(", ");
+    query += ` WHERE config_key IN (${placeholders})`;
+    bindings.push(...keys);
+  }
+
+  query += " ORDER BY config_key";
+
+  const result = await db.prepare(query).bind(...bindings).all<CopilotConfigRow>() as DbResult<CopilotConfigRow>;
+
+  return (result.results ?? []).map((row) => ({
+    key: row.config_key,
+    value: safeJsonParse(row.config_value) ?? row.config_value,
+    description: row.description,
+    category: row.category,
+    updatedAt: row.updated_at,
+  }));
+}
+
+async function fetchCopilotInstructions(db: D1Database, tags?: string[]): Promise<Array<Record<string, unknown>>> {
+  let query = `
+    SELECT instruction_id, title, summary, content, tags, source, updated_at, is_active
+    FROM copilot_instructions
+    WHERE is_active = 1
+  `;
+  const bindings: unknown[] = [];
+
+  if (tags?.length) {
+    const tagFilter = tags.map(() => "tags LIKE ?").join(" OR ");
+    query += ` AND (${tagFilter})`;
+    bindings.push(...tags.map((tag) => `%${tag}%`));
+  }
+
+  query += " ORDER BY updated_at DESC";
+
+  const result = await db.prepare(query).bind(...bindings).all<CopilotInstructionRow>() as DbResult<CopilotInstructionRow>;
+
+  return (result.results ?? []).map((row) => ({
+    id: row.instruction_id,
+    title: row.title,
+    summary: row.summary,
+    content: row.content,
+    tags: safeJsonParse<string[]>(row.tags) ?? [],
+    source: row.source,
+    updatedAt: row.updated_at,
+  }));
+}
+
+async function fetchCopilotQuestions(db: D1Database, status?: string): Promise<Array<Record<string, unknown>>> {
+  let query = `
+    SELECT question_id, repo, question, context_json, status, response, metadata, created_at, updated_at
+    FROM copilot_questions
+  `;
+  const bindings: unknown[] = [];
+
+  if (status) {
+    query += " WHERE status = ?";
+    bindings.push(status);
+  }
+
+  query += " ORDER BY created_at DESC";
+
+  const result = await db.prepare(query).bind(...bindings).all<CopilotQuestionRow>() as DbResult<CopilotQuestionRow>;
+
+  return (result.results ?? []).map((row) => ({
+    id: row.question_id,
+    repo: row.repo,
+    question: row.question,
+    context: safeJsonParse<Record<string, unknown>>(row.context_json),
+    status: row.status,
+    response: row.response,
+    metadata: safeJsonParse<Record<string, unknown>>(row.metadata),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }));
+}
+
+async function fetchCopilotTasks(db: D1Database, status?: string): Promise<Array<Record<string, unknown>>> {
+  let query = `
+    SELECT task_id, title, description, status, source, source_reference, priority, due_at, metadata, created_at, updated_at
+    FROM copilot_task_links
+  `;
+  const bindings: unknown[] = [];
+
+  if (status) {
+    query += " WHERE status = ?";
+    bindings.push(status);
+  }
+
+  query += " ORDER BY COALESCE(due_at, updated_at) ASC";
+
+  const manual = await db.prepare(query).bind(...bindings).all<CopilotTaskRow>() as DbResult<CopilotTaskRow>;
+
+  const manualTasks = (manual.results ?? []).map((row) => ({
+    taskId: row.task_id,
+    title: row.title,
+    description: row.description,
+    status: row.status,
+    source: row.source,
+    sourceReference: row.source_reference,
+    priority: row.priority,
+    dueAt: row.due_at,
+    metadata: safeJsonParse<Record<string, unknown>>(row.metadata),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    readOnly: false,
+    type: "manual",
+  }));
+
+  const agentRequests = await db.prepare(`
+    SELECT request_id, repo, status, request_type, project_type, created_at, updated_at
+    FROM agent_generation_requests
+    ORDER BY created_at DESC
+    LIMIT 25
+  `).all<{
+    request_id: string;
+    repo: string;
+    status: string;
+    request_type: string;
+    project_type: string | null;
+    created_at: number;
+    updated_at: number;
+  }>() as DbResult<{
+    request_id: string;
+    repo: string;
+    status: string;
+    request_type: string;
+    project_type: string | null;
+    created_at: number;
+    updated_at: number;
+  }>;
+
+  const infraRequests = await db.prepare(`
+    SELECT request_id, repo, status, infra_type, created_at, updated_at
+    FROM infrastructure_guidance_requests
+    ORDER BY created_at DESC
+    LIMIT 25
+  `).all<{
+    request_id: string;
+    repo: string;
+    status: string;
+    infra_type: string;
+    created_at: number;
+    updated_at: number;
+  }>() as DbResult<{
+    request_id: string;
+    repo: string;
+    status: string;
+    infra_type: string;
+    created_at: number;
+    updated_at: number;
+  }>;
+
+  const agentTasks = (agentRequests.results ?? [])
+    .filter((row) => !status || row.status === status)
+    .map((row) => ({
+      taskId: row.request_id,
+      title: `Agent generation for ${row.repo}`,
+      status: row.status,
+      source: "agent_generation",
+      sourceReference: row.repo,
+      metadata: {
+        requestType: row.request_type,
+        projectType: row.project_type,
+      },
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      readOnly: true,
+      type: "agent_generation",
+    }));
+
+  const infraTasks = (infraRequests.results ?? [])
+    .filter((row) => !status || row.status === status)
+    .map((row) => ({
+      taskId: row.request_id,
+      title: `Infra guidance: ${row.repo}`,
+      status: row.status,
+      source: "infra_guidance",
+      sourceReference: row.repo,
+      metadata: {
+        infraType: row.infra_type,
+      },
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      readOnly: true,
+      type: "infra_guidance",
+    }));
+
+  return [...manualTasks, ...agentTasks, ...infraTasks];
+}
+
+async function createCopilotQuestion(db: D1Database, params: { question: string; repo?: string; context?: unknown; metadata?: unknown; }): Promise<{ id: string; status: string; createdAt: number; }> {
+  const questionId = crypto.randomUUID();
+  const createdAt = Date.now();
+
+  await db.prepare(`
+    INSERT INTO copilot_questions (question_id, repo, question, context_json, status, metadata, created_at, updated_at)
+    VALUES (?, ?, ?, ?, 'open', ?, ?, ?)
+  `).bind(
+    questionId,
+    params.repo || null,
+    params.question,
+    params.context ? JSON.stringify(params.context) : null,
+    params.metadata ? JSON.stringify(params.metadata) : null,
+    createdAt,
+    createdAt,
+  ).run();
+
+  return { id: questionId, status: "open", createdAt };
+}
+
+async function createManualTask(db: D1Database, params: { title: string; description?: string; priority?: number; dueAt?: number; metadata?: unknown; }): Promise<{ id: string; status: string; createdAt: number; }> {
+  const taskId = crypto.randomUUID();
+  const createdAt = Date.now();
+
+  await db.prepare(`
+    INSERT INTO copilot_task_links (task_id, title, description, status, source, priority, due_at, metadata, created_at, updated_at)
+    VALUES (?, ?, ?, 'pending', 'manual', ?, ?, ?, ?, ?)
+  `).bind(
+    taskId,
+    params.title,
+    params.description || null,
+    params.priority ?? null,
+    params.dueAt ?? null,
+    params.metadata ? JSON.stringify(params.metadata) : null,
+    createdAt,
+    createdAt,
+  ).run();
+
+  return { id: taskId, status: "pending", createdAt };
+}
+
+async function updateManualTaskStatus(db: D1Database, params: { taskId: string; status: string; metadata?: unknown; }): Promise<{ id: string; status: string; updatedAt: number; }> {
+  const updatedAt = Date.now();
+
+  const result = await db.prepare(`
+    UPDATE copilot_task_links
+    SET status = ?, metadata = COALESCE(?, metadata), updated_at = ?
+    WHERE task_id = ?
+  `).bind(
+    params.status,
+    params.metadata ? JSON.stringify(params.metadata) : null,
+    updatedAt,
+    params.taskId,
+  ).run();
+
+  if (!result.success || (result.changes ?? 0) === 0) {
+    throw new Error(`Task ${params.taskId} not found or unchanged.`);
+  }
+
+  return { id: params.taskId, status: params.status, updatedAt };
+}
+
+function listToolDefinitions() {
+  const toolConfig = DEFAULT_MCP_TOOLS.mcpServers["github-copilot-mcp"];
+  const tools = toolConfig?.tools ?? [];
+
+  const definitions: Record<string, { description: string; inputSchema: Record<string, unknown>; }> = {
+    get_copilot_config: {
+      description: "Retrieve GitHub Copilot workspace configuration records.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          keys: {
+            type: "array",
+            description: "Optional list of configuration keys to retrieve.",
+            items: { type: "string" },
+          },
+        },
+      },
+    },
+    list_instructions: {
+      description: "List operational instruction documents for the workspace.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          tags: {
+            type: "array",
+            items: { type: "string" },
+            description: "Filter instructions by tag keyword.",
+          },
+        },
+      },
+    },
+    submit_question: {
+      description: "Store a follow-up question for maintainers to answer.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          question: { type: "string", description: "Question Copilot wants a human to answer." },
+          repo: { type: "string", description: "Optional repository context." },
+          context: { description: "Additional JSON context to persist with the question." },
+          metadata: { description: "Structured metadata to associate with the question." },
+        },
+        required: ["question"],
+      },
+    },
+    list_questions: {
+      description: "Retrieve existing questions submitted by Copilot.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          status: { type: "string", description: "Optional status filter." },
+        },
+      },
+    },
+    list_tasks: {
+      description: "List manual and system-derived tasks for the workspace.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          status: { type: "string", description: "Optional manual task status filter." },
+        },
+      },
+    },
+    create_manual_task: {
+      description: "Create a new manual task tracked inside the Copilot workspace.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          description: { type: "string" },
+          priority: { type: "integer" },
+          dueAt: { type: "integer", description: "Due timestamp in milliseconds." },
+          metadata: { description: "Additional JSON metadata." },
+        },
+        required: ["title"],
+      },
+    },
+    update_task_status: {
+      description: "Update the status of a manual task.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          taskId: { type: "string" },
+          status: { type: "string" },
+          metadata: { description: "Optional metadata patch." },
+        },
+        required: ["taskId", "status"],
+      },
+    },
+  };
+
+  return tools.map((name) => ({
+    name,
+    description: definitions[name]?.description ?? "Custom MCP tool.",
+    inputSchema: definitions[name]?.inputSchema ?? { type: "object" },
+  }));
+}
+
+export async function createCopilotMcpSseResponse(db: D1Database): Promise<Response> {
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const sessionEvent = {
+        type: "session",
+        session: {
+          id: crypto.randomUUID(),
+          name: "github-copilot-mcp",
+          version: "1.0.0",
+          capabilities: {
+            resources: true,
+            tools: true,
+          },
+          timestamp: new Date().toISOString(),
+        },
+      };
+
+      controller.enqueue(encodeSse(sessionEvent));
+
+      const [configs, instructions] = await Promise.all([
+        fetchCopilotConfigs(db),
+        fetchCopilotInstructions(db),
+      ]);
+
+      const resourceEvent = {
+        type: "resources",
+        resources: [
+          {
+            uri: "copilot://configs",
+            name: "GH Bot workspace configuration",
+            description: "Key/value configuration entries for GitHub Copilot.",
+            mimeType: "application/json",
+            stats: { count: configs.length },
+          },
+          {
+            uri: "copilot://instructions",
+            name: "Operational instructions",
+            description: "Instruction documents referenced during Copilot sessions.",
+            mimeType: "application/json",
+            stats: { count: instructions.length },
+          },
+          {
+            uri: "copilot://tasks",
+            name: "Task dashboard",
+            description: "Manual and system-sourced tasks for the workspace.",
+            mimeType: "application/json",
+          },
+          {
+            uri: "copilot://questions/open",
+            name: "Open Copilot questions",
+            description: "Unresolved questions submitted by GitHub Copilot.",
+            mimeType: "application/json",
+          },
+        ],
+      };
+
+      controller.enqueue(encodeSse(resourceEvent));
+
+      const toolsEvent = {
+        type: "tools",
+        tools: listToolDefinitions(),
+      };
+
+      controller.enqueue(encodeSse(toolsEvent));
+
+      const readyEvent = {
+        type: "ready",
+        message: "GitHub Copilot MCP workspace is ready.",
+        stats: {
+          configs: configs.length,
+          instructions: instructions.length,
+        },
+        timestamp: new Date().toISOString(),
+      };
+
+      controller.enqueue(encodeSse(readyEvent));
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+export async function handleCopilotResourceRequest(db: D1Database, uri: string): Promise<Record<string, unknown>> {
+  switch (uri) {
+    case "copilot://configs": {
+      const configs = await fetchCopilotConfigs(db);
+      return { uri, data: configs };
+    }
+    case "copilot://instructions": {
+      const instructions = await fetchCopilotInstructions(db);
+      return { uri, data: instructions };
+    }
+    case "copilot://tasks": {
+      const tasks = await fetchCopilotTasks(db);
+      return { uri, data: tasks };
+    }
+    case "copilot://questions/open": {
+      const questions = await fetchCopilotQuestions(db, "open");
+      return { uri, data: questions };
+    }
+    default:
+      throw new Error(`Unsupported resource URI: ${uri}`);
+  }
+}
+
+export async function handleCopilotToolInvocation(db: D1Database, invocation: CopilotToolInvocation) {
+  if (!invocation || !invocation.tool) {
+    throw new Error("Tool name is required.");
+  }
+
+  const args = invocation.arguments ?? {};
+
+  switch (invocation.tool) {
+    case "get_copilot_config": {
+      const configs = await fetchCopilotConfigs(db, Array.isArray((args as any).keys) ? (args as any).keys : undefined);
+      return {
+        ok: true,
+        tool: invocation.tool,
+        result: { configs },
+        timestamp: new Date().toISOString(),
+      };
+    }
+    case "list_instructions": {
+      const instructions = await fetchCopilotInstructions(db, Array.isArray((args as any).tags) ? (args as any).tags : undefined);
+      return {
+        ok: true,
+        tool: invocation.tool,
+        result: { instructions },
+        timestamp: new Date().toISOString(),
+      };
+    }
+    case "submit_question": {
+      const question = (args as any).question as string | undefined;
+      if (!question || !question.trim()) {
+        throw new Error("question argument is required");
+      }
+      const record = await createCopilotQuestion(db, {
+        question,
+        repo: typeof (args as any).repo === "string" ? (args as any).repo : undefined,
+        context: (args as any).context,
+        metadata: (args as any).metadata,
+      });
+      return {
+        ok: true,
+        tool: invocation.tool,
+        result: record,
+        timestamp: new Date().toISOString(),
+      };
+    }
+    case "list_questions": {
+      const status = typeof (args as any).status === "string" ? (args as any).status : undefined;
+      const questions = await fetchCopilotQuestions(db, status);
+      return {
+        ok: true,
+        tool: invocation.tool,
+        result: { questions },
+        timestamp: new Date().toISOString(),
+      };
+    }
+    case "list_tasks": {
+      const status = typeof (args as any).status === "string" ? (args as any).status : undefined;
+      const tasks = await fetchCopilotTasks(db, status);
+      return {
+        ok: true,
+        tool: invocation.tool,
+        result: { tasks },
+        timestamp: new Date().toISOString(),
+      };
+    }
+    case "create_manual_task": {
+      const title = (args as any).title as string | undefined;
+      if (!title || !title.trim()) {
+        throw new Error("title argument is required");
+      }
+      const record = await createManualTask(db, {
+        title,
+        description: typeof (args as any).description === "string" ? (args as any).description : undefined,
+        priority: typeof (args as any).priority === "number" ? (args as any).priority : undefined,
+        dueAt: typeof (args as any).dueAt === "number" ? (args as any).dueAt : undefined,
+        metadata: (args as any).metadata,
+      });
+      return {
+        ok: true,
+        tool: invocation.tool,
+        result: record,
+        timestamp: new Date().toISOString(),
+      };
+    }
+    case "update_task_status": {
+      const taskId = (args as any).taskId as string | undefined;
+      const status = (args as any).status as string | undefined;
+      if (!taskId || !status) {
+        throw new Error("taskId and status arguments are required");
+      }
+      const record = await updateManualTaskStatus(db, {
+        taskId,
+        status,
+        metadata: (args as any).metadata,
+      });
+      return {
+        ok: true,
+        tool: invocation.tool,
+        result: record,
+        timestamp: new Date().toISOString(),
+      };
+    }
+    default:
+      throw new Error(`Unsupported tool: ${invocation.tool}`);
+  }
+}

--- a/src/modules/mcp_tools.ts
+++ b/src/modules/mcp_tools.ts
@@ -77,6 +77,19 @@ export const DEFAULT_MCP_TOOLS: McpToolsConfig = {
         "search_cloudflare_documentation",
         "migrate_pages_to_workers_guide"
       ]
+    },
+    "github-copilot-mcp": {
+      type: "sse",
+      url: "{{worker_base_url}}/mcp/github-copilot/sse",
+      tools: [
+        "get_copilot_config",
+        "list_instructions",
+        "submit_question",
+        "list_questions",
+        "list_tasks",
+        "create_manual_task",
+        "update_task_status"
+      ]
     }
   }
 }

--- a/tests/test_mcp_tools_integration.sh
+++ b/tests/test_mcp_tools_integration.sh
@@ -60,6 +60,13 @@ else
   exit 1
 fi
 
+if grep -q "github-copilot-mcp" migrations/0009_github_copilot_mcp.sql; then
+  echo "✅ GitHub Copilot MCP server seeded in migration"
+else
+  echo "❌ Missing GitHub Copilot MCP server seed"
+  exit 1
+fi
+
 # Test 4: Check webhook integration
 echo ""
 echo "🪝 Test 4: Validating webhook MCP tools integration..."
@@ -111,6 +118,13 @@ if grep -q "search_cloudflare_documentation" src/modules/mcp_tools.ts; then
   echo "✅ Found required docs tool: search_cloudflare_documentation"
 else
   echo "❌ Missing required docs tool"
+  exit 1
+fi
+
+if grep -q "github-copilot-mcp" src/modules/mcp_tools.ts; then
+  echo "✅ GitHub Copilot MCP server present in defaults"
+else
+  echo "❌ Missing GitHub Copilot MCP server in defaults"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- add a GitHub Copilot MCP SSE endpoint with tool and resource handlers for configs, instructions, questions, and tasks
- seed new D1 tables plus default tool configuration for the Copilot workspace and document the integration
- update defaults and MCP integration tests to cover the new Copilot server

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd900aba90832e8158d2bb3026a422